### PR TITLE
API response format

### DIFF
--- a/src/backend/internal/controllers/user.go
+++ b/src/backend/internal/controllers/user.go
@@ -26,13 +26,23 @@ func (ctrl *User) Register(c *gin.Context) {
 	}
     //check if there is a binding error or empty firstname or lastname
 	if err != nil || len(user.FirstName) == 0 || len(user.LastName) == 0{
-		c.AbortWithStatusJSON(http.StatusUnprocessableEntity, gin.H{"message": "All fields are required"})
+		c.AbortWithStatusJSON(
+			http.StatusUnprocessableEntity, 
+			gin.H{
+				"status": http.StatusUnprocessableEntity,
+				"message": "All fields are required",
+			})
 		return	
 	}
 	hashPassword, err := HashPassword(user.Password)
 	if err != nil {
 		log.Error(err)
-		c.JSON(http.StatusInternalServerError, gin.H{})
+		c.JSON(
+			http.StatusInternalServerError, 
+			gin.H{
+				"status": http.StatusInternalServerError,
+				"message": "Something went wrong",
+			})
 		return
 	}
 	user.Password = hashPassword
@@ -40,13 +50,23 @@ func (ctrl *User) Register(c *gin.Context) {
 
 	if err != nil && rows > 0 {
 		log.Error(err)
-		c.JSON(http.StatusConflict, gin.H{"message": "User already exists"})
+		c.JSON(
+			http.StatusConflict, 
+			gin.H{
+				"status": http.StatusConflict,
+				"message": "User already exists",
+			})
 
 	} else if err == nil && rows == 1 {
 		c.JSON(http.StatusOK, gin.H{"message": "Successfully registered"})
 	} else {
 		log.Error(err)
-		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"message": err.Error()})
+		c.AbortWithStatusJSON(
+			http.StatusInternalServerError, 
+			gin.H{
+				"status": http.StatusInternalServerError,
+				"message": err.Error(),
+			})
 	}
 
 }

--- a/src/backend/internal/middlewares/jwt.go
+++ b/src/backend/internal/middlewares/jwt.go
@@ -66,7 +66,7 @@ func JWTMiddleware(DB *gorm.DB,secret string, secureCookie bool, httpOnly bool) 
 			LoginResponse: func(c *gin.Context, code int, token string, expire time.Time) {
 				c.JSON(http.StatusOK, gin.H{
 					"status":   http.StatusOK,
-					"message": "Logged in successfully"
+					"message": "Logged in successfully",
 					"token":  token,
 					"expire": expire.Format(time.RFC3339),
 				})
@@ -74,7 +74,7 @@ func JWTMiddleware(DB *gorm.DB,secret string, secureCookie bool, httpOnly bool) 
 			RefreshResponse: func(c *gin.Context, code int, token string, expire time.Time) {
 				c.JSON(http.StatusOK, gin.H{
 					"status":   http.StatusOK,
-					"message": "Token refreshed"
+					"message": "Token refreshed",
 					"token":  token,
 					"expire": expire.Format(time.RFC3339),
 				})
@@ -82,9 +82,9 @@ func JWTMiddleware(DB *gorm.DB,secret string, secureCookie bool, httpOnly bool) 
 			LogoutResponse: func(c *gin.Context, code int) {
 				c.JSON(http.StatusOK, gin.H{
 					"status": http.StatusOK,
-					"message": "Logged out successfully"
+					"message": "Logged out successfully",
 				})
-			}
+			},
 			SendCookie: true,
 			SecureCookie: secureCookie,
 			CookieHTTPOnly: httpOnly,

--- a/src/backend/internal/middlewares/jwt.go
+++ b/src/backend/internal/middlewares/jwt.go
@@ -78,6 +78,12 @@ func JWTMiddleware(DB *gorm.DB,secret string, secureCookie bool, httpOnly bool) 
 					"token":  token,
 					"expire": expire.Format(time.RFC3339),
 				})
+			},
+			LogoutResponse: func(c *gin.Context, code int) {
+				c.JSON(http.StatusOK, gin.H{
+					"status": http.StatusOK,
+					"message": "Logged out successfully"
+				})
 			}
 			SendCookie: true,
 			SecureCookie: secureCookie,

--- a/src/backend/internal/middlewares/jwt.go
+++ b/src/backend/internal/middlewares/jwt.go
@@ -4,7 +4,7 @@ import (
 	"github.com/wuraLab/boardly/src/backend/internal/errors"
 	log "github.com/sirupsen/logrus"
 	"time"
-
+	"net/http"
 	"github.com/wuraLab/boardly/src/backend/internal/controllers"
 	"github.com/wuraLab/boardly/src/backend/internal/models"
 	jwt "github.com/appleboy/gin-jwt/v2"
@@ -59,8 +59,16 @@ func JWTMiddleware(DB *gorm.DB,secret string, secureCookie bool, httpOnly bool) 
 			Unauthorized: func(c *gin.Context, code int, message string) {
 				log.Error(errors.NewBadRequest(message))
 				c.JSON(code, gin.H{
-					"code":    code,
+					"status":    code,
 					"message": message,
+				})
+			},
+			LoginResponse: func(c *gin.Context, code int, token string, expire time.Time) {
+				c.JSON(http.StatusOK, gin.H{
+					"status":   http.StatusOK,
+					"message": "Logged in successfully"
+					"token":  token,
+					"expire": expire.Format(time.RFC3339),
 				})
 			},
 			SendCookie: true,

--- a/src/backend/internal/middlewares/jwt.go
+++ b/src/backend/internal/middlewares/jwt.go
@@ -71,6 +71,14 @@ func JWTMiddleware(DB *gorm.DB,secret string, secureCookie bool, httpOnly bool) 
 					"expire": expire.Format(time.RFC3339),
 				})
 			},
+			RefreshResponse: func(c *gin.Context, code int, token string, expire time.Time) {
+				c.JSON(http.StatusOK, gin.H{
+					"status":   http.StatusOK,
+					"message": "Token refreshed"
+					"token":  token,
+					"expire": expire.Format(time.RFC3339),
+				})
+			}
 			SendCookie: true,
 			SecureCookie: secureCookie,
 			CookieHTTPOnly: httpOnly,


### PR DESCRIPTION
closes #90 

updated response format to follow 

```json
 {
    "status":  statusCode,
    "messge": "human friendly message for status",
}
```

This format is effected on the
* Login endpoint
* Logout endpoint
* Refresh token endpoint
* Register endpoint